### PR TITLE
Change -Weverything to -Wall for more compilers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ if(UNIX)
     target_link_libraries(discord-rpc PUBLIC pthread)
     target_compile_options(discord-rpc PRIVATE
         -g
-        -Weverything
+        -Wall
         -Wno-unknown-pragmas # pragma push thing doesn't work on clang
         -Wno-old-style-cast # it's fine
         -Wno-c++98-compat # that was almost 2 decades ago

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,9 @@ if(UNIX)
     target_compile_options(discord-rpc PRIVATE
         -g
         -Wall
+        -Wextra
+        -Wpedantic
+        -Werror
         -Wno-unknown-pragmas # pragma push thing doesn't work on clang
         -Wno-old-style-cast # it's fine
         -Wno-c++98-compat # that was almost 2 decades ago


### PR DESCRIPTION
I've tested the change on both `clang++` and `g++`. Before this update GCC's implementation could not compile, but with it both `clang++` and `g++` can.