### PR TITLE
Support compilers without -Weverything

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,10 @@ if(UNIX)
     target_link_libraries(discord-rpc PUBLIC pthread)
     target_compile_options(discord-rpc PRIVATE
         -g
-        -Weverything
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Werror
         -Wno-unknown-pragmas # pragma push thing doesn't work on clang
         -Wno-old-style-cast # it's fine
         -Wno-c++98-compat # that was almost 2 decades ago


### PR DESCRIPTION
`-Weverything` is not a valid GCC option which was causing compile errors on my Linux install. I've replaced it with a sensible default, which enables all recommended warnings, all pedantic warnings and then upgrades warnings to errors.