### PR TITLE
Create Appveyor config for automated CI testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,8 @@
 version: '{build}'
 install:
-  - mkdir thirdparty
-  - cd thirdparty
-  - set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
-  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
-  - 7z x cmake.zip -o%cd% > nul
-  - move cmake-* cmake
-  - set PATH=%cd%\cmake\bin;%PATH%
-  - cmake --version
-  - cd ..
-  - python --version
   - python -m pip install click
 
 build_script:
-  - python --version
-  - python -m pip install click
   - mkdir examples\unrealstatus\Plugins\discordrpc\Binaries\ThirdParty\discordrpcLibrary\Win64
   - python build.py
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: '{build}'
+install:
+- cmd: >-
+    mkdir thirdparty
+
+    cd thirdparty
+
+    set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
+
+    appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+
+    7z x cmake.zip -o%cd% > nul
+
+    move cmake-* cmake
+
+    set PATH=%cd%\cmake\bin;%PATH%
+
+    cmake --version
+
+    cd ..
+build_script:
+- cmd: >-
+    mkdir build
+
+    cd build
+
+    cmake .. -DCMAKE_INSTALL_PREFIX="C:\Program Files (x86)\DiscordRPC"
+
+    cmake --build . --config Release --target install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,29 @@
 version: '{build}'
 install:
-- cmd: >-
-    mkdir thirdparty
+  - mkdir thirdparty
+  - cd thirdparty
+  - set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -o%cd% > nul
+  - move cmake-* cmake
+  - set PATH=%cd%\cmake\bin;%PATH%
+  - cmake --version
+  - cd ..
+  - python --version
+  - python -m pip install click
 
-    cd thirdparty
-
-    set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
-
-    appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
-
-    7z x cmake.zip -o%cd% > nul
-
-    move cmake-* cmake
-
-    set PATH=%cd%\cmake\bin;%PATH%
-
-    cmake --version
-
-    cd ..
 build_script:
-- cmd: >-
-    mkdir build
+  - python --version
+  - python -m pip install click
+  - mkdir examples\unrealstatus\Plugins\discordrpc\Binaries\ThirdParty\discordrpcLibrary\Win64
+  - python build.py
 
-    cd build
-
-    cmake .. -DCMAKE_INSTALL_PREFIX="C:\Program Files (x86)\DiscordRPC"
-
-    cmake --build . --config Release --target install
+artifacts:
+- path: builds\win32-dynamic
+  name: win32-dynamic
+- path: builds\win32-static
+  name: win32-static
+- path: builds\win64-dynamic
+  name: win64-dynamic
+- path: builds\win64-static
+  name: win64-static


### PR DESCRIPTION
A successful Appveyor build: https://ci.appveyor.com/project/judge2020/discord-rpc/build/4

The install script will first download and install cmake 3.8.0, then use it to build as stated in the readme.

Appveyor must first be requested, then approved by the organization owner at https://github.com/organizations/discordapp/settings/oauth_application_policy. Then this repository must be enabled at https://ci.appveyor.com/projects/new by an organization member.

Note: the appveyor URL will be linked to the member who enables it, so if [Chris](https://github.com/crmarsh) enables it the permalink will be `https://ci.appveyor.com/project/crmarsh/discord-rpc`.