### PR TITLE
Add entry for include folder where you have to place discord-rpc.h

### DIFF
--- a/examples/unrealstatus/Plugins/discordrpc/Source/ThirdParty/discordrpcLibrary/discordrpcLibrary.Build.cs
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/ThirdParty/discordrpcLibrary/discordrpcLibrary.Build.cs
@@ -12,6 +12,7 @@ public class discordrpcLibrary : ModuleRules
 		if (Target.Platform == UnrealTargetPlatform.Win64)
 		{
 			// Add the import library
+			PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Include"));
 			PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "x64", "Release"));
 			PublicAdditionalLibraries.Add("discord-rpc.lib");
 


### PR DESCRIPTION
UE4 requires the include file from the release zip file to be somewhere, so I suggest making a new folder in \Plugins\discordrpc\Source\ThirdParty\discordrpcLibrary called Include and add it there.