### PR TITLE
Fix #16 and #17

### DIFF
--- a/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Private/discordrpc.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Private/discordrpc.cpp
@@ -2,8 +2,8 @@
 
 #include "discordrpc.h"
 #include "Core.h"
-#include "ModuleManager.h"
 #include "IPluginManager.h"
+#include "ModuleManager.h"
 
 #define LOCTEXT_NAMESPACE "FdiscordrpcModule"
 

--- a/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Public/DiscordRpcBlueprint.h
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Public/DiscordRpcBlueprint.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include "Engine.h"
 #include "CoreMinimal.h"
 #include "DiscordRpcBlueprint.generated.h"
+#include "Engine.h"
 
 // unreal's header tool hates clang-format
 // clang-format off

--- a/src/backoff.h
+++ b/src/backoff.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <stdint.h>
 #include <algorithm>
 #include <random>
+#include <stdint.h>
 #include <time.h>
 
 struct Backoff {

--- a/src/connection_win.cpp
+++ b/src/connection_win.cpp
@@ -4,8 +4,8 @@
 #define NOMCX
 #define NOSERVICE
 #define NOIME
-#include <windows.h>
 #include <assert.h>
+#include <windows.h>
 
 int GetProcessId()
 {

--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -91,6 +91,6 @@ extern "C" void Discord_Register(const char* applicationId, const char* command)
 extern "C" void Discord_RegisterSteamGame(const char* applicationId, const char* steamId)
 {
     char command[256];
-    sprintf(command, "xdg-open steam://run/%s", steamId);
+    sprintf(command, "xdg-open steam://rungameid/%s", steamId);
     Discord_Register(applicationId, command);
 }

--- a/src/discord_register_osx.m
+++ b/src/discord_register_osx.m
@@ -92,6 +92,6 @@ void Discord_Register(const char* applicationId, const char* command)
 void Discord_RegisterSteamGame(const char* applicationId, const char* steamId)
 {
     char command[256];
-    sprintf(command, "steam://run/%s", steamId);
+    sprintf(command, "steam://rungameid/%s", steamId);
     Discord_Register(applicationId, command);
 }

--- a/src/discord_register_win.cpp
+++ b/src/discord_register_win.cpp
@@ -121,7 +121,7 @@ extern "C" void Discord_RegisterSteamGame(const char* applicationId, const char*
     }
 
     wchar_t command[1024];
-    StringCbPrintfW(command, sizeof(command), L"\"%s\" steam://run/%s", steamPath, wSteamId);
+    StringCbPrintfW(command, sizeof(command), L"\"%s\" steam://rungameid/%s", steamPath, wSteamId);
 
     Discord_RegisterW(appId, command);
 }

--- a/src/discord_register_win.cpp
+++ b/src/discord_register_win.cpp
@@ -5,9 +5,9 @@
 #define NOMCX
 #define NOSERVICE
 #define NOIME
-#include <windows.h>
 #include <Psapi.h>
 #include <Strsafe.h>
+#include <windows.h>
 #pragma comment(lib, "Psapi.lib")
 
 void Discord_RegisterW(const wchar_t* applicationId, const wchar_t* command)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -11,8 +11,8 @@
 #pragma warning(disable : 6313) // Incorrect operator
 
 #include "rapidjson/document.h"
-#include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
 #pragma warning(pop)
 

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -79,6 +79,9 @@ public:
         }
         // allocate how much you need in the first place
         assert(!originalPtr && !originalSize);
+        // unused parameter warning
+        (void)(originalPtr);
+        (void)(originalSize);
         return Malloc(newSize);
     }
     static void Free(void* ptr)


### PR DESCRIPTION
The change from `steam://run` to `steam://rungameid` allows to launch mods without a Steam ID (fixes #16); the addition of two lines in `LinearAllocator::Realloc()` fixes an unused argument warning/error when compiling with `CMAKE_BUILD_TYPE=Release` (fixes #17).

The clang-format commit is the changes I got when running cmake for the first time (it clang-formats automatically).