### PR TITLE
Add clang-format include categories

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,6 +30,15 @@ DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros: [ foreach ]
+IncludeCategories:
+  - Regex: '^("|<)stdafx\.h(pp)?("|>)'
+    Priority: -1
+  - Regex: '^("|<)(W|w)indows\.h("|>)'
+    Priority: 1
+  - Regex: '^<.*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 10
 IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false

--- a/src/connection_win.cpp
+++ b/src/connection_win.cpp
@@ -4,8 +4,8 @@
 #define NOMCX
 #define NOSERVICE
 #define NOIME
-#include <assert.h>
 #include <windows.h>
+#include <assert.h>
 
 int GetProcessId()
 {

--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -1,5 +1,5 @@
-#include "discord-rpc.h"
 #include <stdio.h>
+#include "discord-rpc.h"
 
 #include <errno.h>
 #include <stdlib.h>

--- a/src/discord_register_win.cpp
+++ b/src/discord_register_win.cpp
@@ -1,5 +1,5 @@
-#include "discord-rpc.h"
 #include <stdio.h>
+#include "discord-rpc.h"
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMCX


### PR DESCRIPTION
This makes clang-format sort `<stdafx.h>` first (required by VS, if a precompiled header is ever used), then `<windows.h>` (must be above some other headers), then any other `<headers>`, then the rest.

Fixes `windows.h` getting sorted below `Psapi.h` (which results in compile errors). Tested this on Windows and it does compile fine (VS 2017).

Please tell me if you would like any changes (like removing the `stdafx` and `<headers>` rules or adding a `discord-rpc.h` rule).