### PR TITLE
Improve cmakelists for vcpkg building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.7.0)
 project (DiscordRPC)
 
+option(BUILD_EXAMPLES "Build example apps" ON)
+
 # format
 file(GLOB_RECURSE ALL_SOURCE_FILES
     examples/*.cpp examples/*.h examples/*.c
@@ -51,4 +53,6 @@ add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
 # add subdirs
 
 add_subdirectory(src)
-add_subdirectory(examples/send-presence)
+if (BUILD_EXAMPLES)
+    add_subdirectory(examples/send-presence)
+endif(BUILD_EXAMPLES)

--- a/build.py
+++ b/build.py
@@ -73,9 +73,9 @@ def main(clean):
         generator64 = 'Visual Studio 14 2015 Win64'
 
         build_lib('win32-static', generator32, {})
-        build_lib('win32-dynamic', generator32, {'BUILD_SHARED_LIBS': True})
+        build_lib('win32-dynamic', generator32, {'BUILD_SHARED_LIBS': True, 'USE_STATIC_CRT': True})
         build_lib('win64-static', generator64, {})
-        build_lib('win64-dynamic', generator64, {'BUILD_SHARED_LIBS': True})
+        build_lib('win64-dynamic', generator64, {'BUILD_SHARED_LIBS': True, 'USE_STATIC_CRT': True})
 
         # todo: this in some better way
         src_dll = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release', 'discord-rpc.dll')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,6 @@ if(WIN32)
     add_library(discord-rpc ${BASE_RPC_SRC})
     if (MSVC)
     target_compile_options(discord-rpc PRIVATE /EHsc
-        /MT
         /Wall
         /wd4100 # unreferenced formal parameter
         /wd4514 # unreferenced inline
@@ -105,13 +104,10 @@ install(
     EXPORT "discord-rpc"
     RUNTIME
         DESTINATION "bin"
-        CONFIGURATIONS Release
     LIBRARY
         DESTINATION "lib"
-        CONFIGURATIONS Release
     ARCHIVE
         DESTINATION "lib"
-        CONFIGURATIONS Release
     INCLUDES
         DESTINATION "include"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 option(ENABLE_IO_THREAD "Start up a separate I/O thread, otherwise I'd need to call an update function" ON)
+option(USE_STATIC_CRT "Use /MT[d] for dynamic library" OFF)
 
 set(BASE_RPC_SRC
     ${PROJECT_SOURCE_DIR}/include/discord-rpc.h
@@ -22,11 +23,21 @@ if (${BUILD_SHARED_LIBS})
 endif(${BUILD_SHARED_LIBS})
 
 if(WIN32)
+    set(CRT_FLAGS)
+    if(USE_STATIC_CRT)
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(CRT_FLAGS /MTd)
+        else()
+            set(CRT_FLAGS /MT)
+        endif()
+    endif(USE_STATIC_CRT)
+
     add_definitions(-DDISCORD_WINDOWS)
     set(BASE_RPC_SRC ${BASE_RPC_SRC} connection_win.cpp discord_register_win.cpp)
     add_library(discord-rpc ${BASE_RPC_SRC})
     if (MSVC)
     target_compile_options(discord-rpc PRIVATE /EHsc
+        ${CRT_FLAGS}
         /Wall
         /wd4100 # unreferenced formal parameter
         /wd4514 # unreferenced inline

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,34 +23,33 @@ if (${BUILD_SHARED_LIBS})
 endif(${BUILD_SHARED_LIBS})
 
 if(WIN32)
-    set(CRT_FLAGS)
-    if(USE_STATIC_CRT)
-        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-            set(CRT_FLAGS /MTd)
-        else()
-            set(CRT_FLAGS /MT)
-        endif()
-    endif(USE_STATIC_CRT)
-
     add_definitions(-DDISCORD_WINDOWS)
     set(BASE_RPC_SRC ${BASE_RPC_SRC} connection_win.cpp discord_register_win.cpp)
     add_library(discord-rpc ${BASE_RPC_SRC})
     if (MSVC)
-    target_compile_options(discord-rpc PRIVATE /EHsc
-        ${CRT_FLAGS}
-        /Wall
-        /wd4100 # unreferenced formal parameter
-        /wd4514 # unreferenced inline
-        /wd4625 # copy constructor deleted
-        /wd5026 # move constructor deleted
-        /wd4626 # move assignment operator deleted
-        /wd4668 # not defined preprocessor macro
-        /wd4710 # function not inlined
-        /wd4711 # function was inlined
-        /wd4820 # structure padding
-        /wd4946 # reinterpret_cast used between related classes
-        /wd5027 # move assignment operator was implicitly defined as deleted
-    )
+        set(CRT_FLAGS)
+        if(USE_STATIC_CRT)
+            if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+                set(CRT_FLAGS /MTd)
+            else()
+                set(CRT_FLAGS /MT)
+            endif()
+        endif(USE_STATIC_CRT)
+        target_compile_options(discord-rpc PRIVATE /EHsc
+            ${CRT_FLAGS}
+            /Wall
+            /wd4100 # unreferenced formal parameter
+            /wd4514 # unreferenced inline
+            /wd4625 # copy constructor deleted
+            /wd5026 # move constructor deleted
+            /wd4626 # move assignment operator deleted
+            /wd4668 # not defined preprocessor macro
+            /wd4710 # function not inlined
+            /wd4711 # function was inlined
+            /wd4820 # structure padding
+            /wd4946 # reinterpret_cast used between related classes
+            /wd5027 # move assignment operator was implicitly defined as deleted
+        )
     endif(MSVC)
     target_link_libraries(discord-rpc PRIVATE psapi)
 endif(WIN32)


### PR DESCRIPTION
In order to add as a port to [vcpkg](https://github.com/Microsoft/vcpkg), I needed to patch the cmakelists with the following changes:
- Remove forced /MT directive (the CRT depends on debug or release, static or dynamic).
- Allow building for debug by removing the force configuration release.
- Add option to prevent building of example apps.

If these can be merged upstream then I can do away with the diff patch in vcpkg. Thanks.
Related PR: https://github.com/Microsoft/vcpkg/pull/2174