### PR TITLE
Use simpler version of GetModuleFileNameW

### DIFF
--- a/src/discord_register_win.cpp
+++ b/src/discord_register_win.cpp
@@ -28,7 +28,7 @@ void Discord_RegisterW(const wchar_t* applicationId, const wchar_t* command)
     // Update the HKEY_CURRENT_USER, because it doesn't seem to require special permissions.
 
     wchar_t exeFilePath[MAX_PATH];
-    DWORD exeLen = GetModuleFileNameExW(GetCurrentProcess(), nullptr, exeFilePath, MAX_PATH);
+    DWORD exeLen = GetModuleFileNameW(nullptr, exeFilePath, MAX_PATH);
     wchar_t openCommand[1024];
 
     if (command && command[0]) {


### PR DESCRIPTION
As per
https://msdn.microsoft.com/en-us/library/windows/desktop/ms683198(v=vs.85).aspx,
the advised use for getting the file name of a module from `<current
process>` is to use the simplified version. Additionally, this clears
the confusion introduced in Win7's PSAPI which moved
`GetModuleFileNameExW` into the kernel, changing its signature to
`K32GetModuleFileNameExW`, effectively breaking pre-Win7 uses unless
actively mitigated with `#define PSAPI_VERSION 1`