### PR TITLE
allow mingw compile without pthread dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mingw-std-threads"]
+	path = mingw-std-threads
+	url = https://github.com/meganz/mingw-std-threads.git

--- a/src/discord-rpc.cpp
+++ b/src/discord-rpc.cpp
@@ -8,11 +8,20 @@
 
 #include <atomic>
 #include <chrono>
+
 #include <mutex>
+#if defined _WIN32 && defined __GNUC__ && !defined _GLIBCXX_HAS_GTHREADS
+#include "../mingw-std-threads/mingw.mutex.h"
+#endif
 
 #ifndef DISCORD_DISABLE_IO_THREAD
+#if defined _WIN32 && defined __GNUC__ && !defined _GLIBCXX_HAS_GTHREADS
+#include "../mingw-std-threads/mingw.condition_variable.h"
+#include "../mingw-std-threads/mingw.thread.h"
+#else
 #include <condition_variable>
 #include <thread>
+#endif
 #endif
 
 constexpr size_t MaxMessageSize{16 * 1024};


### PR DESCRIPTION
Background: The Mingw tool chain does not implement native windows threads for libstdc++ thread support. Instead they implement them via their winpthread wrapper. That is okay but adds an additional .dll to be deployed (there is no static lib version available).

To avoid always shipping with the additional winpthread dependency Mingw usually comes in flavors: one with C++ threading support but winpthread dependency and one without winpthread dependency but also without thread support.

This patch adds thread support in case Mingw flavor without thread support is being chosen. This is done via a importing a submodule from "meganz" which adds a lightweight native win32 C++ thread layer instead.

The #includes are lazy/clumsy as I don't speak CMake. Feel free to move things around. But I felt people may find this useful.