### PR TITLE
Update README.md to correct JavaScript mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ Below is a table of unofficial, community-developed wrappers for and implementat
 |------|----------|
 | [Java-DiscordRPC](https://github.com/MinnDevelopment/Java-DiscordRPC) | Java |
 | [Discord-IPC](https://github.com/jagrosh/DiscordIPC) | Java |
-| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | [Node.js](https://nodejs.org/en/) |
+| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | [Node.js](https://nodejs.org/) |
 | [drpc4k](https://github.com/Bluexin/drpc4k) | [Kotlin](https://kotlinlang.org/) |
 | [SwordRPC](https://github.com/Azoy/SwordRPC) | [Swift](https://swift.org) |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ Below is a table of unofficial, community-developed wrappers for and implementat
 |------|----------|
 | [Java-DiscordRPC](https://github.com/MinnDevelopment/Java-DiscordRPC) | Java |
 | [Discord-IPC](https://github.com/jagrosh/DiscordIPC) | Java |
-| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | Node.js |
+| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | [Node.js](https://nodejs.org/en/) |
 | [drpc4k](https://github.com/Bluexin/drpc4k) | [Kotlin](https://kotlinlang.org/) |
 | [SwordRPC](https://github.com/Azoy/SwordRPC) | [Swift](https://swift.org) |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ Below is a table of unofficial, community-developed wrappers for and implementat
 |------|----------|
 | [Java-DiscordRPC](https://github.com/MinnDevelopment/Java-DiscordRPC) | Java |
 | [Discord-IPC](https://github.com/jagrosh/DiscordIPC) | Java |
-| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | JavaScript |
+| [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | Node.js |
 | [drpc4k](https://github.com/Bluexin/drpc4k) | [Kotlin](https://kotlinlang.org/) |
 | [SwordRPC](https://github.com/Azoy/SwordRPC) | [Swift](https://swift.org) |


### PR DESCRIPTION
It's not a JavaScript library, it's a Node.js library and should be explicitly stated to avoid confusion with https://github.com/discordapp/discord-rpc/issues/11.

*I linked to the Node.js library just to make it similar to the rest.