### PR TITLE
make ready() to explicitly take no arguments -> ready(void)

### DIFF
--- a/include/discord-rpc.h
+++ b/include/discord-rpc.h
@@ -49,7 +49,7 @@ typedef struct DiscordJoinRequest {
 } DiscordJoinRequest;
 
 typedef struct DiscordEventHandlers {
-    void (*ready)();
+    void (*ready)(void);
     void (*disconnected)(int errorCode, const char* message);
     void (*errored)(int errorCode, const char* message);
     void (*joinGame)(const char* joinSecret);


### PR DESCRIPTION
This change fixes a compilation error in case strict prototypes are treated as errors:
```
error: function declaration isn’t a prototype [-Werror=strict-prototypes]
     void (*ready)();
```
