### PR TITLE
add `Discord_ClearPresence()`

### DIFF
--- a/examples/button-clicker/Assets/DiscordRpc.cs
+++ b/examples/button-clicker/Assets/DiscordRpc.cs
@@ -78,6 +78,9 @@ public class DiscordRpc
     [DllImport("discord-rpc", EntryPoint = "Discord_UpdatePresence", CallingConvention = CallingConvention.Cdecl)]
     public static extern void UpdatePresence(ref RichPresence presence);
 
+    [DllImport("discord-rpc", EntryPoint = "Discord_ClearPresence", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void ClearPresence();
+
     [DllImport("discord-rpc", EntryPoint = "Discord_Respond", CallingConvention = CallingConvention.Cdecl)]
     public static extern void Respond(string userId, Reply reply);
 }

--- a/examples/send-presence/send-presence.c
+++ b/examples/send-presence/send-presence.c
@@ -14,6 +14,7 @@
 static const char* APPLICATION_ID = "345229890980937739";
 static int FrustrationLevel = 0;
 static int64_t StartTime;
+static int SendPresence = 1;
 
 static int prompt(char* line, size_t size)
 {
@@ -32,24 +33,28 @@ static int prompt(char* line, size_t size)
 
 static void updateDiscordPresence()
 {
-    char buffer[256];
-    DiscordRichPresence discordPresence;
-    memset(&discordPresence, 0, sizeof(discordPresence));
-    discordPresence.state = "West of House";
-    sprintf(buffer, "Frustration level: %d", FrustrationLevel);
-    discordPresence.details = buffer;
-    discordPresence.startTimestamp = StartTime;
-    discordPresence.endTimestamp = time(0) + 5 * 60;
-    discordPresence.largeImageKey = "canary-large";
-    discordPresence.smallImageKey = "ptb-small";
-    discordPresence.partyId = "party1234";
-    discordPresence.partySize = 1;
-    discordPresence.partyMax = 6;
-    discordPresence.matchSecret = "xyzzy";
-    discordPresence.joinSecret = "join";
-    discordPresence.spectateSecret = "look";
-    discordPresence.instance = 0;
-    Discord_UpdatePresence(&discordPresence);
+    if (SendPresence) {
+        char buffer[256];
+        DiscordRichPresence discordPresence;
+        memset(&discordPresence, 0, sizeof(discordPresence));
+        discordPresence.state = "West of House";
+        sprintf(buffer, "Frustration level: %d", FrustrationLevel);
+        discordPresence.details = buffer;
+        discordPresence.startTimestamp = StartTime;
+        discordPresence.endTimestamp = time(0) + 5 * 60;
+        discordPresence.largeImageKey = "canary-large";
+        discordPresence.smallImageKey = "ptb-small";
+        discordPresence.partyId = "party1234";
+        discordPresence.partySize = 1;
+        discordPresence.partyMax = 6;
+        discordPresence.matchSecret = "xyzzy";
+        discordPresence.joinSecret = "join";
+        discordPresence.spectateSecret = "look";
+        discordPresence.instance = 0;
+        Discord_UpdatePresence(&discordPresence);
+    } else {
+        Discord_ClearPresence();
+    }
 }
 
 static void handleDiscordReady()
@@ -140,6 +145,18 @@ static void gameLoop()
             if (line[0] == 't') {
                 printf("Shutting off Discord.\n");
                 Discord_Shutdown();
+                continue;
+            }
+
+            if (line[0] == 'c') {
+                if (SendPresence) {
+                    printf("Clearing presence information.\n");
+                    SendPresence = 0;
+                } else {
+                    printf("Restoring presence information.\n");
+                    SendPresence = 1;
+                }
+                updateDiscordPresence();
                 continue;
             }
 

--- a/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Private/DiscordRpcBlueprint.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Private/DiscordRpcBlueprint.cpp
@@ -145,3 +145,8 @@ void UDiscordRpc::UpdatePresence()
 
     Discord_UpdatePresence(&rp);
 }
+
+void UDiscordRpc::ClearPresence()
+{
+    Discord_ClearPresence();
+}

--- a/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Public/DiscordRpcBlueprint.h
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/discordrpc/Public/DiscordRpcBlueprint.h
@@ -108,6 +108,11 @@ public:
               Category = "Discord")
     void UpdatePresence();
 
+    UFUNCTION(BlueprintCallable,
+              meta = (DisplayName = "Clear presence", Keywords = "Discord rpc"),
+              Category = "Discord")
+    void ClearPresence();
+
     UPROPERTY(BlueprintReadOnly,
               meta = (DisplayName = "Is Discord connected", Keywords = "Discord rpc"),
               Category = "Discord")

--- a/include/discord-rpc.h
+++ b/include/discord-rpc.h
@@ -76,6 +76,7 @@ DISCORD_EXPORT void Discord_UpdateConnection(void);
 #endif
 
 DISCORD_EXPORT void Discord_UpdatePresence(const DiscordRichPresence* presence);
+DISCORD_EXPORT void Discord_ClearPresence();
 
 DISCORD_EXPORT void Discord_Respond(const char* userid, /* DISCORD_REPLY_ */ int reply);
 

--- a/src/discord-rpc.cpp
+++ b/src/discord-rpc.cpp
@@ -325,6 +325,11 @@ extern "C" DISCORD_EXPORT void Discord_UpdatePresence(const DiscordRichPresence*
     SignalIOActivity();
 }
 
+extern "C" DISCORD_EXPORT void Discord_ClearPresence()
+{
+    Discord_UpdatePresence(nullptr);
+}
+
 extern "C" DISCORD_EXPORT void Discord_Respond(const char* userId, /* DISCORD_REPLY_ */ int reply)
 {
     // if we are not connected, let's not batch up stale messages for later

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -102,6 +102,7 @@ size_t JsonWriteRichPresenceObj(char* dest,
             WriteKey(writer, "pid");
             writer.Int(pid);
 
+            if (presence != nullptr)
             {
                 WriteObject activity(writer, "activity");
 


### PR DESCRIPTION
send-presence example updated - start a line with 'c' to toggle
whether presence information is sent or not.

Added ClearPresence to .cs bindings

Added ClearPresence to UE4 blueprint class.