### PR TITLE
Fix segfaults in Discord_RegisterW in MinGW builds

### DIFF
--- a/src/serialization.h
+++ b/src/serialization.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 
+#ifndef __MINGW32__
 #pragma warning(push)
 
 #pragma warning(disable : 4061) // enum is not explicitly handled by a case label
@@ -9,12 +10,15 @@
 #pragma warning(disable : 4464) // relative include path contains
 #pragma warning(disable : 4668) // is not defined as a preprocessor macro
 #pragma warning(disable : 6313) // Incorrect operator
+#endif // __MINGW32__
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+#ifndef __MINGW32__
 #pragma warning(pop)
+#endif // __MINGW32__
 
 // if only there was a standard library function for this
 template <size_t Len>


### PR DESCRIPTION
The first test of my patch provided in issue #102 ended up in a segfault. Turns out strsafe.h substitution was insufficient and could lead to stack corruption. It was caused by a simple lack of size conversion, when wchars in different functions are treated as bytes or as wchars. The aim of this PR is to fix this problem.

* Replaced the StringCbPrintfW macro with a proper function for a size conversion could be provided
* Replaced the only occasion of StringCbCopyW with a StringCbPrintfW call, as it is used elsewhere in this function, so it's buggy substitute function could be safely removed
* Prevented a few possible failures in the RegSetKeyValueW syscall substitute (according to MSDN references)
* Fixed indentation in substitute functions