### PR TITLE
Update build.py to properly build and copy libraries for Unity and Unreal

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ This is a text adventure "game" that inits/deinits the connection to Discord, an
 
 ## Sample: button-clicker
 
-This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button. Run `python build.py unity` in the root directory to download the correct library files and place them in their respective folders.
+This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button. Run `python build.py unity` in the root directory to build the correct library files and place them in their respective folders.
 
 ## Sample: unrealstatus
 
-This is a sample [Unreal](https://www.unrealengine.com) project that wraps the DLL version of the library with an Unreal plugin, exposes a blueprint class for interacting with it, and uses that to make a very simple UI. Run `python build.py unreal` in the root directory to download the correct library files and place them in their respective folders.
+This is a sample [Unreal](https://www.unrealengine.com) project that wraps the DLL version of the library with an Unreal plugin, exposes a blueprint class for interacting with it, and uses that to make a very simple UI. Run `python build.py unreal` in the root directory to build the correct library files and place them in their respective folders.
 
 ## Wrappers and Implementations
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a text adventure "game" that inits/deinits the connection to Discord, an
 
 ## Sample: button-clicker
 
-This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button. Run `python build.py unity` in the root directory to download the correct library files.
+This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button. Run `python build.py unity` in the root directory to download the correct library files and place them in their respective folders.
 
 ## Sample: unrealstatus
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ This is a text adventure "game" that inits/deinits the connection to Discord, an
 
 ## Sample: button-clicker
 
-This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button.
+This is a sample [Unity](https://unity3d.com/) project that wraps a DLL version of the library, and sends presence updates when you click on a button. Run `python build.py unity` in the root directory to download the correct library files.
 
 ## Sample: unrealstatus
 
-This is a sample [Unreal](https://www.unrealengine.com) project that wraps the DLL version of the library with an Unreal plugin, exposes a blueprint class for interacting with it, and uses that to make a very simple UI.
+This is a sample [Unreal](https://www.unrealengine.com) project that wraps the DLL version of the library with an Unreal plugin, exposes a blueprint class for interacting with it, and uses that to make a very simple UI. Run `python build.py unreal` in the root directory to download the correct library files and place them in their respective folders.
 
 ## Wrappers and Implementations
 

--- a/build.py
+++ b/build.py
@@ -80,14 +80,35 @@ def unity(ctx):
     )
 
     click.echo('--- Copying libs and header into unity example')
+    UNITY_PROJECT_PATH = os.path.join(SCRIPT_PATH, 'examples', 'button-clicker', 'Assets', 'Plugins')
 
-    if sys.platform.startswith('win'):
-        return 'win'
+    if sys.platform == 'win64':
+        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
+        UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86_64')
+        LIBRARY_NAME = 'discord-rpc.dll'
+
+    elif sys.platform == 'win32':
+        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win32-dynamic', 'src', 'Release')
+        UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86')
+        LIBRARY_NAME = 'discord-rpc.dll'
+
     elif sys.platform == 'darwin':
-        return 'osx'
+        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'osx-dynamic', 'src')
+        UNITY_DLL_PATH = UNITY_PROJECT_PATH
+        os.rename(os.path.join(BUILD_BASE_PATH, 'libdiscord-rpc.dylib'), os.path.join(BUILD_BASE_PATH, 'discord-rpc.bundle'))
+        LIBRARY_NAME = 'discord-rpc.bundle'
+
     elif sys.platform.startswith('linux'):
-        return 'linux'
-    raise Exception('Unsupported platform ' + sys.platform)
+        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'linux-dynamic', 'src')
+        UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86')
+        os.rename(os.path.join(BUILD_BASE_PATH, 'libdiscord-rpc.so'), os.path.join(BUILD_BASE_PATH, 'discord-rpc.so'))
+        LIBRARY_NAME = 'discord-rpc.so'
+
+    else:
+        raise Exception('Unsupported platform ' + sys.platform)
+
+    mkdir_p(UNITY_DLL_PATH)
+    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNITY_DLL_PATH)
 
 
 @cli.command()

--- a/build.py
+++ b/build.py
@@ -112,18 +112,19 @@ def unreal(ctx):
 
     elif sys.platform == 'darwin':
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'osx-dynamic', 'src')
-        UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'OSX')
+        UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Mac')
         LIBRARY_NAME = 'libdiscord-rpc.dylib'
 
     elif sys.platform.startswith('linux'):
-        return 'linux'
+        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'linux-dynamic', 'src')
+        UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Linux')
+        LIBRARY_NAME = 'libdiscord-rpc.so'
 
     else:
         raise Exception('Unsupported platform ' + sys.platform)
 
-    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_DLL_PATH)
-
     UNREAL_INCLUDE_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Include')
+
     mkdir_p(UNREAL_INCLUDE_PATH)
     shutil.copy(os.path.join(SCRIPT_PATH, 'include', 'discord-rpc.h'), UNREAL_INCLUDE_PATH)
 

--- a/build.py
+++ b/build.py
@@ -78,37 +78,44 @@ def unity(ctx):
         skip_formatter=True,
         just_release=True
     )
+    BUILDS = []
 
     click.echo('--- Copying libs and header into unity example')
     UNITY_PROJECT_PATH = os.path.join(SCRIPT_PATH, 'examples', 'button-clicker', 'Assets', 'Plugins')
 
-    if sys.platform == 'win64':
-        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
-        UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86_64')
+    if sys.platform.startswith('win'):
         LIBRARY_NAME = 'discord-rpc.dll'
+        BUILD_64_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
+        UNITY_64_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86_64')
+        BUILDS.append({BUILD_64_BASE_PATH: UNITY_64_DLL_PATH})
 
-    elif sys.platform == 'win32':
-        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win32-dynamic', 'src', 'Release')
-        UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86')
-        LIBRARY_NAME = 'discord-rpc.dll'
+        BUILD_32_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win32-dynamic', 'src', 'Release')
+        UNITY_32_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86')
+        BUILDS.append({BUILD_32_BASE_PATH: UNITY_32_DLL_PATH})
 
     elif sys.platform == 'darwin':
+        LIBRARY_NAME = 'discord-rpc.bundle'
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'osx-dynamic', 'src')
         UNITY_DLL_PATH = UNITY_PROJECT_PATH
         os.rename(os.path.join(BUILD_BASE_PATH, 'libdiscord-rpc.dylib'), os.path.join(BUILD_BASE_PATH, 'discord-rpc.bundle'))
-        LIBRARY_NAME = 'discord-rpc.bundle'
+
+        BUILDS.append({BUILD_BASE_PATH: UNITY_DLL_PATH})
 
     elif sys.platform.startswith('linux'):
+        LIBRARY_NAME = 'discord-rpc.so'
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'linux-dynamic', 'src')
         UNITY_DLL_PATH = os.path.join(UNITY_PROJECT_PATH, 'x86')
         os.rename(os.path.join(BUILD_BASE_PATH, 'libdiscord-rpc.so'), os.path.join(BUILD_BASE_PATH, 'discord-rpc.so'))
-        LIBRARY_NAME = 'discord-rpc.so'
+
+        BUILDS.append({BUILD_BASE_PATH: UNITY_DLL_PATH})
 
     else:
         raise Exception('Unsupported platform ' + sys.platform)
 
-    mkdir_p(UNITY_DLL_PATH)
-    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNITY_DLL_PATH)
+    for build in BUILDS:
+        for i in build:
+            mkdir_p(build[i])
+            shutil.copy(os.path.join(i, LIBRARY_NAME), build[i])
 
 
 @cli.command()
@@ -123,34 +130,45 @@ def unreal(ctx):
         skip_formatter=True,
         just_release=True
     )
+    BUILDS = []
+
     click.echo('--- Copying libs and header into unreal example')
     UNREAL_PROJECT_PATH = os.path.join(SCRIPT_PATH, 'examples', 'unrealstatus', 'Plugins', 'discordrpc')
+    UNREAL_INCLUDE_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Include')
+    mkdir_p(UNREAL_INCLUDE_PATH)
+    shutil.copy(os.path.join(SCRIPT_PATH, 'include', 'discord-rpc.h'), UNREAL_INCLUDE_PATH)
 
     if sys.platform.startswith('win'):
-        BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
-        UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Win64')
         LIBRARY_NAME = 'discord-rpc.lib'
+        BUILD_64_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
+        UNREAL_64_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Win64')
+        BUILDS.append({BUILD_64_BASE_PATH: UNREAL_64_DLL_PATH})
+
+        BUILD_32_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win32-dynamic', 'src', 'Release')
+        UNREAL_32_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Win32')
+        BUILDS.append({BUILD_32_BASE_PATH: UNREAL_32_DLL_PATH})
 
     elif sys.platform == 'darwin':
+        LIBRARY_NAME = 'libdiscord-rpc.dylib'
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'osx-dynamic', 'src')
         UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Mac')
-        LIBRARY_NAME = 'libdiscord-rpc.dylib'
+
+        BUILDS.append({BUILD_BASE_PATH: UNREAL_DLL_PATH})
 
     elif sys.platform.startswith('linux'):
+        LIBRARY_NAME = 'libdiscord-rpc.so'
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'linux-dynamic', 'src')
         UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Linux')
-        LIBRARY_NAME = 'libdiscord-rpc.so'
+
+        BUILDS.append({BUILD_BASE_PATH: UNREAL_DLL_PATH})
 
     else:
         raise Exception('Unsupported platform ' + sys.platform)
 
-    UNREAL_INCLUDE_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Include')
-
-    mkdir_p(UNREAL_INCLUDE_PATH)
-    shutil.copy(os.path.join(SCRIPT_PATH, 'include', 'discord-rpc.h'), UNREAL_INCLUDE_PATH)
-
-    mkdir_p(UNREAL_DLL_PATH)
-    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_DLL_PATH)
+    for build in BUILDS:
+        for i in build:
+            mkdir_p(build[i])
+            shutil.copy(os.path.join(i, LIBRARY_NAME), build[i])
 
 
 def build_lib(build_name, generator, options, just_release):

--- a/build.py
+++ b/build.py
@@ -108,13 +108,11 @@ def unreal(ctx):
     if sys.platform.startswith('win'):
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'win64-dynamic', 'src', 'Release')
         UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Win64')
-        UNREAL_LIB_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Win64')
         LIBRARY_NAME = 'discord-rpc.lib'
 
     elif sys.platform == 'darwin':
         BUILD_BASE_PATH = os.path.join(SCRIPT_PATH, 'builds', 'osx-dynamic', 'src')
         UNREAL_DLL_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'OSX')
-        UNREAL_LIB_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'OSX')
         LIBRARY_NAME = 'libdiscord-rpc.dylib'
 
     elif sys.platform.startswith('linux'):
@@ -123,15 +121,13 @@ def unreal(ctx):
     else:
         raise Exception('Unsupported platform ' + sys.platform)
 
-    mkdir_p(UNREAL_DLL_PATH)
     shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_DLL_PATH)
 
     UNREAL_INCLUDE_PATH = os.path.join(UNREAL_PROJECT_PATH, 'Source', 'ThirdParty', 'DiscordRpcLibrary', 'Include')
     mkdir_p(UNREAL_INCLUDE_PATH)
     shutil.copy(os.path.join(SCRIPT_PATH, 'include', 'discord-rpc.h'), UNREAL_INCLUDE_PATH)
 
-    mkdir_p(UNREAL_LIB_PATH)
-    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_LIB_PATH)
+    shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_DLL_PATH)
 
 
 def build_lib(build_name, generator, options, just_release):

--- a/build.py
+++ b/build.py
@@ -127,6 +127,7 @@ def unreal(ctx):
     mkdir_p(UNREAL_INCLUDE_PATH)
     shutil.copy(os.path.join(SCRIPT_PATH, 'include', 'discord-rpc.h'), UNREAL_INCLUDE_PATH)
 
+    mkdir_p(UNREAL_DLL_PATH)
     shutil.copy(os.path.join(BUILD_BASE_PATH, LIBRARY_NAME), UNREAL_DLL_PATH)
 
 

--- a/examples/button-clicker/Assets/Editor/BuildHelper.cs
+++ b/examples/button-clicker/Assets/Editor/BuildHelper.cs
@@ -27,7 +27,7 @@ public class ScriptBatch
 		proc.StartInfo.EnvironmentVariables["PATH"] = newPath;
 #endif
 		proc.StartInfo.FileName = "python";
-		proc.StartInfo.Arguments = "build.py for_unity";
+		proc.StartInfo.Arguments = "build.py unity";
 		proc.StartInfo.WorkingDirectory = "../..";
 		proc.Start();
 		proc.WaitForExit();


### PR DESCRIPTION
Currently, `build.py unity` only creates the libs and does not move them to the right place, and `build.py unreal` does nothing. This PR aims to have the script properly create and move the libs to their proper folders for either target based on operating system.

In the future, the `BuildHelper.cs` script can probably be changed to reference this instead, but it's not currently harmful.