### PR TITLE
Making partyMax required if partySize is included

### DIFF
--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -138,12 +138,10 @@ size_t JsonWriteRichPresenceObj(char* dest,
                     presence->partyMax) {
                     WriteObject party(writer, "party");
                     WriteOptionalString(writer, "id", presence->partyId);
-                    if (presence->partySize) {
+                    if (presence->partySize && presence->partyMax) {
                         WriteArray size(writer, "size");
                         writer.Int(presence->partySize);
-                        if (0 < presence->partyMax) {
-                            writer.Int(presence->partyMax);
-                        }
+                        writer.Int(presence->partyMax);
                     }
                 }
 


### PR DESCRIPTION
Currently in the SDK serialization, `partyMax` is an optional field, and one can send a `partySize` without including a max. This will throw an error from discord of:

```
"child "activity" fails because [child "party" fails because [child "size" fails because ["size" must contain 2 items]]]"
```

This PR aims to fix this by making it mandatory to include both `partySize` and `partyMax` if attempting to serialize `party.size`. Rather than throwing an error, the SDK will not write `party.size` to Discord if both fields are missing.

This also fixes #111.

EDIT examples:

Code:

```cs
public void OnClick()
    {
        Debug.Log("Discord: on click!");
        clickCounter++;

        DiscordRpc.RichPresence presence = new DiscordRpc.RichPresence();

        presence.details = string.Format("Button clicked {0} times", clickCounter);
        presence.state = "Kappa";
        presence.partySize = 99;
        presence.partyId = "12312312312313";
        presence.joinSecret = "qwidhjquwhd";

        DiscordRpc.UpdatePresence(ref presence);
    }
```

Discord receives:

![image](https://user-images.githubusercontent.com/4193854/35934689-18002994-0bf3-11e8-8c4c-bb36adca155c.png)
