### PR TITLE
Dynamic Event Handler Registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,23 +28,23 @@ endif(CLANG_FORMAT_CMD)
 
 # thirdparty stuff
 execute_process(
-    COMMAND mkdir ${CMAKE_SOURCE_DIR}/thirdparty
+    COMMAND mkdir ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     ERROR_QUIET
 )
 
-find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 if (NOT RAPIDJSONTEST)
     message("no rapidjson, download")
-    set(RJ_TAR_FILE ${CMAKE_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
+    set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
     file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/thirdparty
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     )
     file(REMOVE ${RJ_TAR_FILE})
 endif(NOT RAPIDJSONTEST)
 
-find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 
 add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ have callbacks for where a more complete game would do more things (joining, spe
 
 ## Documentation
 
-The most up to date documentation for Rich Presence can always be found in our [developer site](https://discordapp.com/developers/docs/rich-presence/how-to)!
+The most up to date documentation for Rich Presence can always be found on our [developer site](https://discordapp.com/developers/docs/rich-presence/how-to)! If you're interested in rolling your own native implementation of Rich Presence via IPC sockets instead of using our SDK—hey, you've got free time, right?—check out the ["Hard Mode" documentation](https://github.com/discordapp/discord-rpc/blob/master/documentation/hard-mode.md).
 
 ## Basic Usage
 

--- a/build.py
+++ b/build.py
@@ -224,7 +224,7 @@ def sign():
         sign_command_base = [
             tool,
             'sign',
-            '/n', 'Hammer & Chisel Inc.',
+            '/n', 'Discord Inc.',
             '/a',
             '/tr', 'http://timestamp.digicert.com/rfc3161',
             '/as',

--- a/documentation/hard-mode.md
+++ b/documentation/hard-mode.md
@@ -93,8 +93,7 @@ And third is the `ACTIVITY_JOIN_REQUEST` event:
       "username": "Mason",
       "discriminator": "1337",
       "avatar": "a_bab14f271d565501444b2ca3be944b25"
-    },
-    "secret": "e459ca99273f59909dd16ed97865f3ad"
+    }
   },
   "evt": "ACTIVITY_JOIN_REQUEST"
 }
@@ -125,3 +124,41 @@ In order to receive these events, you need to [subscribe](https://discordapp.com
     "cmd": "SUBSCRIBE"
 }
 ```
+
+To unsubscribe from these events, resend with the command `UNSUBSCRIBE`
+
+## Responding
+A discord user will request access to the game. If the ACTIVITY_JOIN_REQUEST has been subscribed too, the ACTIVITY_JOIN_REQUEST event will be sent to the host's game. Accept it with following model:
+```json
+{
+    "nonce": "5dc0c062-98c6-47a0-8922-15aerg126",
+    "cmd": "SEND_ACTIVITY_JOIN_INVITE",
+    "args": 
+    {
+        "user_id": "53908232506183680"
+    }
+}
+```
+
+To reject the request, use `CLOSE_ACTIVITY_REQUEST`:
+```json
+{
+    "nonce": "5dc0c062-98c6-47a0-8922-dasg256eafg",
+    "cmd": "CLOSE_ACTIVITY_REQUEST",
+    "args": 
+    {
+        "user_id": "53908232506183680"
+    }
+}
+```
+
+## Notes
+Here are just some quick notes to help with some common troubleshooting problems.
+* IPC will echo back every command you send as a response. Use this as a lock-step feature to avoid flooding messages. Can be used to validate messages such as the Presence or Subscribes.
+* The pipe expects for frames to be written in a single byte array. You cannot do multiple `stream.Write(opcode);` `stream.Write(length);` as it will break the pipe. Instead create a buffer, write the data to the buffer, then send the entire buffer to the stream.
+* Discord can be on any pipe ranging from `discord-ipc-0` to `discord-ipc-9`. It is a good idea to try and connect to each one and keeping the first one you connect too. For multiple clients (eg Discord and Canary), you might want to add a feature to manually select the pipe so you can more easily debug the application.
+* All enums are `lower_snake_case`. 
+* The opcode and length in the header are `Little Endian Unsigned Integers (32bits)`. In some languages, you must convert them as they can be architecture specific.
+* [Discord Rich Presence How-To](https://discordapp.com/developers/docs/rich-presence/how-to) contains a lot of the information this document doesn't. For example, it will tell you about the response payload.
+* In the documentation, DISCORD_REPLY_IGNORE is just implemented the same as DISCORD_REPLY_NO.
+* You can test the Join / Spectate feature by enabling them in your profile and whitelisting a test account. Use Canary to run 2 accounts on the same machine.

--- a/examples/button-clicker/Assets/DiscordRpc.cs
+++ b/examples/button-clicker/Assets/DiscordRpc.cs
@@ -87,6 +87,9 @@ public class DiscordRpc
     [DllImport("discord-rpc", EntryPoint = "Discord_Respond", CallingConvention = CallingConvention.Cdecl)]
     public static extern void Respond(string userId, Reply reply);
 
+    [DllImport("discord-rpc", EntryPoint = "Discord_UpdateHandlers", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void UpdateHandlers(ref EventHandlers handlers);
+
     public static void UpdatePresence(RichPresence presence)
     {
         var presencestruct = presence.GetStruct();

--- a/examples/send-presence/send-presence.c
+++ b/examples/send-presence/send-presence.c
@@ -1,5 +1,5 @@
 /*
-    This is a simple example in C of using the rich presence API asyncronously.
+    This is a simple example in C of using the rich presence API asynchronously.
 */
 
 #define _CRT_SECURE_NO_WARNINGS /* thanks Microsoft */

--- a/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpcBlueprint.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpcBlueprint.cpp
@@ -134,6 +134,8 @@ void UDiscordRpc::UpdatePresence()
 
     auto spectateSecret = StringCast<ANSICHAR>(*RichPresence.spectateSecret);
     rp.spectateSecret = spectateSecret.Get();
+    rp.startTimestamp = RichPresence.startTimestamp;
+    rp.endTimestamp = RichPresence.endTimestamp;
     rp.partySize = RichPresence.partySize;
     rp.partyMax = RichPresence.partyMax;
     rp.instance = RichPresence.instance;

--- a/include/discord_rpc.h
+++ b/include/discord_rpc.h
@@ -80,6 +80,8 @@ DISCORD_EXPORT void Discord_ClearPresence(void);
 
 DISCORD_EXPORT void Discord_Respond(const char* userid, /* DISCORD_REPLY_ */ int reply);
 
+DISCORD_EXPORT void Discord_UpdateHandlers(DiscordEventHandlers* handlers);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ if(WIN32)
             /wd5027 # move assignment operator was implicitly defined as deleted
         )
     endif(MSVC)
-    target_link_libraries(discord-rpc PRIVATE psapi)
+    target_link_libraries(discord-rpc PRIVATE psapi advapi32)
 endif(WIN32)
 
 if(UNIX)

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -267,12 +267,7 @@ extern "C" DISCORD_EXPORT void Discord_Initialize(const char* applicationId,
 
     Pid = GetProcessId();
 
-    if (handlers) {
-        Handlers = *handlers;
-    }
-    else {
-        Handlers = {};
-    }
+    Discord_UpdateHandlers(handlers);
 
     if (Connection) {
         return;

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -418,6 +418,9 @@ extern "C" DISCORD_EXPORT void Discord_UpdateHandlers(DiscordEventHandlers* newH
         HANDLE_EVENT_REGISTRATION(joinGame, "ACTIVITY_JOIN")
         HANDLE_EVENT_REGISTRATION(spectateGame, "ACTIVITY_SPECTATE")
         HANDLE_EVENT_REGISTRATION(joinRequest, "ACTIVITY_JOIN_REQUEST")
+
+#undef HANDLE_EVENT_REGISTRATION
+
         std::lock_guard<std::mutex> guard(HandlerMutex);
         Handlers = *newHandlers;
     }

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -373,28 +373,28 @@ extern "C" DISCORD_EXPORT void Discord_RunCallbacks(void)
         }
     }
 
-    if (WasJustConnected.exchange(false) && Handlers.ready) {
+    if (WasJustConnected.exchange(false)) {
         std::lock_guard<std::mutex> guard(HandlerMutex);
         if (Handlers.ready) {
             Handlers.ready();
         }
     }
 
-    if (GotErrorMessage.exchange(false) && Handlers.errored) {
+    if (GotErrorMessage.exchange(false)) {
         std::lock_guard<std::mutex> guard(HandlerMutex);
         if (Handlers.errored) {
             Handlers.errored(LastErrorCode, LastErrorMessage);
         }
     }
 
-    if (WasJoinGame.exchange(false) && Handlers.joinGame) {
+    if (WasJoinGame.exchange(false)) {
         std::lock_guard<std::mutex> guard(HandlerMutex);
         if (Handlers.joinGame) {
             Handlers.joinGame(JoinGameSecret);
         }
     }
 
-    if (WasSpectateGame.exchange(false) && Handlers.spectateGame) {
+    if (WasSpectateGame.exchange(false)) {
         std::lock_guard<std::mutex> guard(HandlerMutex);
         if (Handlers.spectateGame) {
             Handlers.spectateGame(SpectateGameSecret);

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -197,6 +197,25 @@ size_t JsonWriteSubscribeCommand(char* dest, size_t maxLen, int nonce, const cha
     return writer.Size();
 }
 
+size_t JsonWriteUnsubscribeCommand(char* dest, size_t maxLen, int nonce, const char* evtName)
+{
+    JsonWriter writer(dest, maxLen);
+
+    {
+        WriteObject obj(writer);
+
+        JsonWriteNonce(writer, nonce);
+
+        WriteKey(writer, "cmd");
+        writer.String("UNSUBSCRIBE");
+
+        WriteKey(writer, "evt");
+        writer.String(evtName);
+    }
+
+    return writer.Size();
+}
+
 size_t JsonWriteJoinReply(char* dest, size_t maxLen, const char* userId, int reply, int nonce)
 {
     JsonWriter writer(dest, maxLen);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -47,6 +47,8 @@ size_t JsonWriteRichPresenceObj(char* dest,
                                 const DiscordRichPresence* presence);
 size_t JsonWriteSubscribeCommand(char* dest, size_t maxLen, int nonce, const char* evtName);
 
+size_t JsonWriteUnsubscribeCommand(char* dest, size_t maxLen, int nonce, const char* evtName);
+
 size_t JsonWriteJoinReply(char* dest, size_t maxLen, const char* userId, int reply, int nonce);
 
 // I want to use as few allocations as I can get away with, and to do that with RapidJson, you need


### PR DESCRIPTION
Right now, handlers for events are only updated with an `Discord_Initialize()` call, leading to issues like https://github.com/discordapp/discord-rpc/issues/26#issuecomment-352931913.

This PR aims to allow developers to dynamically register new event handlers more easily/explicitly:

1. **Dynamically Register for Spectate/Join/ATJ events based on handlers bound**

2. **Export `Discord_UpdateHandlers()` into the header file**
A more explicit function call is probably better.

3. **Update C# wrapper to include new function call**
Wew.

I'm not sure if it's better practice to lock the mutex on the whole if block, like I did, or on each callback call in the block, so suggestions welcome there.