### PR TITLE
Changed CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,23 +28,23 @@ endif(CLANG_FORMAT_CMD)
 
 # thirdparty stuff
 execute_process(
-    COMMAND mkdir ${CMAKE_SOURCE_DIR}/thirdparty
+    COMMAND mkdir ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     ERROR_QUIET
 )
 
-find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 if (NOT RAPIDJSONTEST)
     message("no rapidjson, download")
-    set(RJ_TAR_FILE ${CMAKE_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
+    set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
     file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/thirdparty
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     )
     file(REMOVE ${RJ_TAR_FILE})
 endif(NOT RAPIDJSONTEST)
 
-find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 
 add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
 


### PR DESCRIPTION
When you used CMAKE_SOURCE_DIR it became an issue when I added discord RPC as a sub directory in cmake so that rapidjson ended up in my root project/thirdparty instead of root project/discord-rpc/thirdparty. changing CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR fixes this.