### PR TITLE
Syntax change to avoid gcc 4.8 segfaulting

### DIFF
--- a/src/msg_queue.h
+++ b/src/msg_queue.h
@@ -7,7 +7,7 @@
 
 template <typename ElementType, size_t QueueSize>
 class MsgQueue {
-    ElementType queue_[QueueSize]{};
+    ElementType queue_[QueueSize];
     std::atomic_uint nextAdd_{0};
     std::atomic_uint nextSend_{0};
     std::atomic_uint pendingSends_{0};


### PR DESCRIPTION
This avoids a segfault in gcc 4.8:

```
lib/discord/src/msg_queue.h: In instantiation of 'MsgQueue<ElementType, QueueSize>::MsgQueue() [with ElementType = QueuedMessage; long unsigned int QueueSize = 8ul]':
lib/discord/src/discord_rpc.cpp:66:50:   required from here
lib/discord/src/msg_queue.h:16:16: internal compiler error: Segmentation fault
MsgQueue() {}
^
Please submit a full bug report,
with preprocessed source if appropriate.
```

I don't think this will have any different kind of behavior, but please correct me if I'm wrong.

Had to fix this, as we *still* currently require gcc 4.8 for building within the Steam Runtime. (Also see https://github.com/ValveSoftware/steam-runtime/issues/55)