### PR TITLE
Changes to the UE4 plugin to not crash with android

### DIFF
--- a/examples/unrealstatus/Plugins/discordrpc/DiscordRpc.uplugin
+++ b/examples/unrealstatus/Plugins/discordrpc/DiscordRpc.uplugin
@@ -22,7 +22,8 @@
 			[
 				"Win64",
 				"Linux",
-				"Mac"
+				"Mac",
+				"Android"
 			]
 		}
 	]

--- a/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpc.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpc.cpp
@@ -27,6 +27,7 @@ void FDiscordRpcModule::StartupModule()
         FMessageDialog::Open(EAppMsgType::Ok, LOCTEXT(LOCTEXT_NAMESPACE, "Failed to load DiscordRpc plugin. Plug-in will not be functional."));
         FreeDependency(DiscordRpcLibraryHandle);
     }
+#elif PLATFORM_ANDROID
 #endif
 #endif
 #endif
@@ -36,8 +37,10 @@ void FDiscordRpcModule::ShutdownModule()
 {
     // Free the dll handle
 #if !PLATFORM_LINUX
+#if !PLATFORM_ANDROID
 #if defined(DISCORD_DYNAMIC_LIB)
     FreeDependency(DiscordRpcLibraryHandle);
+#endif
 #endif
 #endif
 }
@@ -59,11 +62,13 @@ bool FDiscordRpcModule::LoadDependency(const FString& Dir, const FString& Name, 
 
 void FDiscordRpcModule::FreeDependency(void*& Handle)
 {
+#if !PLATFORM_ANDROID
     if (Handle != nullptr)
     {
         FPlatformProcess::FreeDllHandle(Handle);
         Handle = nullptr;
     }
+#endif
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpcBlueprint.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpcBlueprint.cpp
@@ -8,52 +8,63 @@ static UDiscordRpc* self = nullptr;
 
 static void ReadyHandler()
 {
+#if !PLATFORM_ANDROID
     UE_LOG(Discord, Log, TEXT("Discord connected"));
     if (self) {
         self->IsConnected = true;
         self->OnConnected.Broadcast();
     }
+#endif
 }
 
 static void DisconnectHandler(int errorCode, const char* message)
 {
+#if !PLATFORM_ANDROID
     auto msg = FString(message);
     UE_LOG(Discord, Log, TEXT("Discord disconnected (%d): %s"), errorCode, *msg);
     if (self) {
         self->IsConnected = false;
         self->OnDisconnected.Broadcast(errorCode, msg);
     }
+#endif
 }
 
 static void ErroredHandler(int errorCode, const char* message)
 {
+#if !PLATFORM_ANDROID
     auto msg = FString(message);
     UE_LOG(Discord, Log, TEXT("Discord error (%d): %s"), errorCode, *msg);
     if (self) {
         self->OnErrored.Broadcast(errorCode, msg);
     }
+#endif
 }
 
 static void JoinGameHandler(const char* joinSecret)
 {
+#if !PLATFORM_ANDROID
     auto secret = FString(joinSecret);
     UE_LOG(Discord, Log, TEXT("Discord join %s"), *secret);
     if (self) {
         self->OnJoin.Broadcast(secret);
     }
+#endif
 }
 
 static void SpectateGameHandler(const char* spectateSecret)
 {
+#if !PLATFORM_ANDROID
     auto secret = FString(spectateSecret);
     UE_LOG(Discord, Log, TEXT("Discord spectate %s"), *secret);
     if (self) {
         self->OnSpectate.Broadcast(secret);
     }
+#endif
 }
 
 static void JoinRequestHandler(const DiscordJoinRequest* request)
 {
+#if !PLATFORM_ANDROID
     FDiscordJoinRequestData jr;
     jr.userId = ANSI_TO_TCHAR(request->userId);
     jr.username = ANSI_TO_TCHAR(request->username);
@@ -63,12 +74,14 @@ static void JoinRequestHandler(const DiscordJoinRequest* request)
     if (self) {
         self->OnJoinRequest.Broadcast(jr);
     }
+#endif
 }
 
 void UDiscordRpc::Initialize(const FString& applicationId,
     bool autoRegister,
     const FString& optionalSteamId)
 {
+#if !PLATFORM_ANDROID
     self = this;
     IsConnected = false;
     DiscordEventHandlers handlers{};
@@ -88,21 +101,27 @@ void UDiscordRpc::Initialize(const FString& applicationId,
     auto steamId = StringCast<ANSICHAR>(*optionalSteamId);
     Discord_Initialize(
         (const char*)appId.Get(), &handlers, autoRegister, (const char*)steamId.Get());
+#endif
 }
 
 void UDiscordRpc::Shutdown()
 {
+#if !PLATFORM_ANDROID
     Discord_Shutdown();
     self = nullptr;
+#endif
 }
 
 void UDiscordRpc::RunCallbacks()
 {
+#if !PLATFORM_ANDROID
     Discord_RunCallbacks();
+#endif
 }
 
 void UDiscordRpc::UpdatePresence()
 {
+#if !PLATFORM_ANDROID
     DiscordRichPresence rp{};
 
     auto state = StringCast<ANSICHAR>(*RichPresence.state);
@@ -141,16 +160,21 @@ void UDiscordRpc::UpdatePresence()
     rp.instance = RichPresence.instance;
 
     Discord_UpdatePresence(&rp);
+#endif
 }
 
 void UDiscordRpc::ClearPresence()
 {
+#if !PLATFORM_ANDROID
     Discord_ClearPresence();
+#endif
 }
 
 void UDiscordRpc::Respond(const FString& userId, int reply)
 {
+#if !PLATFORM_ANDROID
     UE_LOG(Discord, Log, TEXT("Responding %d to join request from %s"), reply, *userId);
     FTCHARToUTF8 utf8_userid(*userId);
     Discord_Respond(utf8_userid.Get(), reply);
+#endif
 }


### PR DESCRIPTION
Currently  when you want a crossplatform game for say Windows & Android, the Android version will crash because the module for DiscordRPC is not found. This PR adds the module for android and disables all the functions since DiscordRPC currently doesn't support Android.