### PR TITLE
Add link to DerelictDiscordRPC (D binding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ Below is a table of unofficial, community-developed wrappers for and implementat
 | [Discord Rich Presence](https://npmjs.org/discord-rich-presence) | JavaScript |
 | [drpc4k](https://github.com/Bluexin/drpc4k) | [Kotlin](https://kotlinlang.org/) |
 | [SwordRPC](https://github.com/Azoy/SwordRPC) | [Swift](https://swift.org) |
+| [DerelictDiscordRPC](https://github.com/voidblaster/DerelictDiscordRPC) | [D](https://dlang.org/) |


### PR DESCRIPTION
**DerelictDiscordRPC** is a [dynamic binding](https://derelictorg.github.io/bindings/#dynamic-bindings) for the [D programming language](https://dlang.org/) and uses [Derelict](https://derelictorg.github.io/) for dynamic loading of the library.

The current implementation is based on the latest release (v3.2.0).

If there are any further questions, let me know 🙂 