### PR TITLE
Apply formatting

### DIFF
--- a/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpc.cpp
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Private/DiscordRpc.cpp
@@ -12,19 +12,26 @@ void FDiscordRpcModule::StartupModule()
 #if defined(DISCORD_DYNAMIC_LIB)
     // Get the base directory of this plugin
     FString BaseDir = IPluginManager::Get().FindPlugin("DiscordRpc")->GetBaseDir();
-    const FString SDKDir = FPaths::Combine(*BaseDir, TEXT("Source"), TEXT("ThirdParty"), TEXT("DiscordRpcLibrary"));
+    const FString SDKDir =
+      FPaths::Combine(*BaseDir, TEXT("Source"), TEXT("ThirdParty"), TEXT("DiscordRpcLibrary"));
 #if PLATFORM_WINDOWS
     const FString LibName = TEXT("discord-rpc");
     const FString LibDir = FPaths::Combine(*SDKDir, TEXT("Win64"));
     if (!LoadDependency(LibDir, LibName, DiscordRpcLibraryHandle)) {
-        FMessageDialog::Open(EAppMsgType::Ok, LOCTEXT(LOCTEXT_NAMESPACE, "Failed to load DiscordRpc plugin. Plug-in will not be functional."));
+        FMessageDialog::Open(
+          EAppMsgType::Ok,
+          LOCTEXT(LOCTEXT_NAMESPACE,
+                  "Failed to load DiscordRpc plugin. Plug-in will not be functional."));
         FreeDependency(DiscordRpcLibraryHandle);
     }
 #elif PLATFORM_MAC
     const FString LibName = TEXT("libdiscord-rpc");
     const FString LibDir = FPaths::Combine(*SDKDir, TEXT("Mac"));
     if (!LoadDependency(LibDir, LibName, DiscordRpcLibraryHandle)) {
-        FMessageDialog::Open(EAppMsgType::Ok, LOCTEXT(LOCTEXT_NAMESPACE, "Failed to load DiscordRpc plugin. Plug-in will not be functional."));
+        FMessageDialog::Open(
+          EAppMsgType::Ok,
+          LOCTEXT(LOCTEXT_NAMESPACE,
+                  "Failed to load DiscordRpc plugin. Plug-in will not be functional."));
         FreeDependency(DiscordRpcLibraryHandle);
     }
 #endif
@@ -49,8 +56,7 @@ bool FDiscordRpcModule::LoadDependency(const FString& Dir, const FString& Name, 
 
     Handle = FPlatformProcess::GetDllHandle(*Path);
 
-    if (Handle == nullptr)
-    {
+    if (Handle == nullptr) {
         return false;
     }
 
@@ -59,8 +65,7 @@ bool FDiscordRpcModule::LoadDependency(const FString& Dir, const FString& Name, 
 
 void FDiscordRpcModule::FreeDependency(void*& Handle)
 {
-    if (Handle != nullptr)
-    {
+    if (Handle != nullptr) {
         FPlatformProcess::FreeDllHandle(Handle);
         Handle = nullptr;
     }

--- a/include/discord_register.h
+++ b/include/discord_register.h
@@ -1,17 +1,17 @@
 #pragma once
 
 #if defined(DISCORD_DYNAMIC_LIB)
-#  if defined(_WIN32)
-#    if defined(DISCORD_BUILDING_SDK)
-#      define DISCORD_EXPORT __declspec(dllexport)
-#    else
-#      define DISCORD_EXPORT __declspec(dllimport)
-#    endif
-#  else
-#    define DISCORD_EXPORT __attribute__((visibility("default")))
-#  endif
+#if defined(_WIN32)
+#if defined(DISCORD_BUILDING_SDK)
+#define DISCORD_EXPORT __declspec(dllexport)
 #else
-#  define DISCORD_EXPORT
+#define DISCORD_EXPORT __declspec(dllimport)
+#endif
+#else
+#define DISCORD_EXPORT __attribute__((visibility("default")))
+#endif
+#else
+#define DISCORD_EXPORT
 #endif
 
 #ifdef __cplusplus

--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -91,7 +91,8 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
     }
 }
 
-extern "C" DISCORD_EXPORT void Discord_RegisterSteamGame(const char* applicationId, const char* steamId)
+extern "C" DISCORD_EXPORT void Discord_RegisterSteamGame(const char* applicationId,
+                                                         const char* steamId)
 {
     char command[256];
     sprintf(command, "xdg-open steam://rungameid/%s", steamId);

--- a/src/discord_register_win.cpp
+++ b/src/discord_register_win.cpp
@@ -26,7 +26,8 @@ static HRESULT StringCbPrintfW(LPWSTR pszDest, size_t cbDest, LPCWSTR pszFormat,
     HRESULT ret;
     va_list va;
     va_start(va, pszFormat);
-    cbDest /= 2; // Size is divided by 2 to convert from bytes to wide characters - causes segfault othervise
+    cbDest /= 2; // Size is divided by 2 to convert from bytes to wide characters - causes segfault
+                 // othervise
     ret = vsnwprintf(pszDest, cbDest, pszFormat, va);
     pszDest[cbDest - 1] = 0; // Terminate the string in case a buffer overflow; -1 will be returned
     va_end(va);
@@ -44,17 +45,24 @@ static HRESULT StringCbPrintfW(LPWSTR pszDest, size_t cbDest, LPCWSTR pszFormat,
 #undefine RegSetKeyValueW
 #endif
 #define RegSetKeyValueW regset
-static LSTATUS regset(HKEY hkey, LPCWSTR subkey, LPCWSTR name, DWORD type, const void *data, DWORD len)
+static LSTATUS regset(HKEY hkey,
+                      LPCWSTR subkey,
+                      LPCWSTR name,
+                      DWORD type,
+                      const void* data,
+                      DWORD len)
 {
     HKEY htkey = hkey, hsubkey = nullptr;
     LSTATUS ret;
-    if (subkey && subkey[0])
-    {
-        if((ret = RegCreateKeyExW(hkey, subkey, 0, 0, 0, KEY_ALL_ACCESS, 0, &hsubkey, 0)) != ERROR_SUCCESS) return ret;
+    if (subkey && subkey[0]) {
+        if ((ret = RegCreateKeyExW(hkey, subkey, 0, 0, 0, KEY_ALL_ACCESS, 0, &hsubkey, 0)) !=
+            ERROR_SUCCESS)
+            return ret;
         htkey = hsubkey;
     }
     ret = RegSetValueExW(htkey, name, 0, type, (const BYTE*)data, len);
-    if (hsubkey && hsubkey != hkey) RegCloseKey(hsubkey);
+    if (hsubkey && hsubkey != hkey)
+        RegCloseKey(hsubkey);
     return ret;
 }
 
@@ -72,7 +80,7 @@ static void Discord_RegisterW(const wchar_t* applicationId, const wchar_t* comma
         StringCbPrintfW(openCommand, sizeof(openCommand), L"%s", command);
     }
     else {
-        //StringCbCopyW(openCommand, sizeof(openCommand), exeFilePath);
+        // StringCbCopyW(openCommand, sizeof(openCommand), exeFilePath);
         StringCbPrintfW(openCommand, sizeof(openCommand), L"%s", exeFilePath);
     }
 
@@ -138,7 +146,8 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
     Discord_RegisterW(appId, wcommand);
 }
 
-extern "C" DISCORD_EXPORT void Discord_RegisterSteamGame(const char* applicationId, const char* steamId)
+extern "C" DISCORD_EXPORT void Discord_RegisterSteamGame(const char* applicationId,
+                                                         const char* steamId)
 {
     wchar_t appId[32];
     MultiByteToWideChar(CP_UTF8, 0, applicationId, -1, appId, 32);

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -102,8 +102,7 @@ size_t JsonWriteRichPresenceObj(char* dest,
             WriteKey(writer, "pid");
             writer.Int(pid);
 
-            if (presence != nullptr)
-            {
+            if (presence != nullptr) {
                 WriteObject activity(writer, "activity");
 
                 WriteOptionalString(writer, "state", presence->state);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -10,7 +10,7 @@
 #pragma warning(disable : 4464) // relative include path contains
 #pragma warning(disable : 4668) // is not defined as a preprocessor macro
 #pragma warning(disable : 6313) // Incorrect operator
-#endif // __MINGW32__
+#endif                          // __MINGW32__
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"


### PR DESCRIPTION
It's terribly inconvenient to have clang-format run on each (non-CI) build while the sources are not formatted properly. This applies clang-format rules to prevent re-formatting on each build.