### PR TITLE
Fixed issue with Discord RPC not updating presence during shutdown

### DIFF
--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -89,10 +89,11 @@ public:
         keepRunning.store(true);
         ioThread = std::thread([&]() {
             const std::chrono::duration<int64_t, std::milli> maxWait{500LL};
+            Discord_UpdateConnection();
             while (keepRunning.load()) {
-                Discord_UpdateConnection();
                 std::unique_lock<std::mutex> lock(waitForIOMutex);
                 waitForIOActivity.wait_for(lock, maxWait);
+                Discord_UpdateConnection();
             }
         });
     }


### PR DESCRIPTION
I ran into an issue where this code didn't work correctly
```cpp
Discord_ClearPresence();
Discord_Shutdown();
```
however doing this, gives the desired behavior.
```cpp
Discord_ClearPresence();
//Discord_Shutdown();
```

This PR will allow for the code above to work correctly.

To give a little context, some users asked me to create an option in the UI to disable Rich Presence because of privacy concerns. So, I added the option and had it shutdown Discord RPC when users chose to disable Rich Presence. However, the presence would be stuck and not change until closing the program.

This all happened 6 days ago and I found a fix as described here in this comment. https://github.com/dolphin-emu/dolphin/pull/6983#issuecomment-393745736