### PR TITLE
Added enum for response codes

### DIFF
--- a/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Public/DiscordRpcBlueprint.h
+++ b/examples/unrealstatus/Plugins/discordrpc/Source/DiscordRpc/Public/DiscordRpcBlueprint.h
@@ -24,6 +24,16 @@ struct FDiscordUserData {
     FString avatar;
 };
 
+/**
+* Valid response codes for Respond function
+*/
+UENUM(BlueprintType)
+enum class EDiscordJoinResponseCodes : uint8
+{
+	DISCORD_REPLY_NO		UMETA(DisplayName="No"),
+	DISCORD_REPLY_YES		UMETA(DisplayName="Yes"),
+	DISCORD_REPLY_IGNORE	UMETA(DisplayName="Ignore")
+};
 
 DECLARE_LOG_CATEGORY_EXTERN(Discord, Log, All);
 


### PR DESCRIPTION
Makes it easier to respond to a join request via Blueprints, without having to look it up in the docs.
Completely optional and fully backwards compatible.