### PR TITLE
[Linux] Null-terminate output from readlink in Discord_Register.

### DIFF
--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -33,8 +33,12 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
 
     char exePath[1024];
     if (!command || !command[0]) {
-        if (readlink("/proc/self/exe", exePath, sizeof(exePath)) <= 0) {
+        size_t size = readlink("/proc/self/exe", exePath, sizeof(exePath));
+        if (size <= 0) {
             return;
+        }
+        if (size < sizeof(exePath)) {
+            exePath[size] = '\0';
         }
         command = exePath;
     }

--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -33,13 +33,11 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
 
     char exePath[1024];
     if (!command || !command[0]) {
-        size_t size = readlink("/proc/self/exe", exePath, sizeof(exePath));
-        if (size <= 0) {
+        ssize_t size = readlink("/proc/self/exe", exePath, sizeof(exePath));
+        if (size <= 0 || size >= sizeof(exePath)) {
             return;
         }
-        if (size < sizeof(exePath)) {
-            exePath[size] = '\0';
-        }
+        exePath[size] = '\0';
         command = exePath;
     }
 


### PR DESCRIPTION
### The problem
I'm working on integrating Discord Rich Presence into my game, including using `Discord_Register` to register the launcher instead of the game itself. My development OS is Linux Mint. After reverting back and setting autoRegister to 1 when calling `Discord_Initialize`, something broke in the desktop application that it generates: when I attempted to launch the game from Discord using the 'Spectate' button, a popup appeared:

***Failed to open URI "discord-471xxxxxxxxxxxx348://".***
*The specified location is not supported.*

When I opened up *~/.local/share/applications/discord-471xxxxxxxxxxxx348.desktop*, I saw that there were three garbage characters **fݝ$** appended to the end of the file path:
```
[Desktop Entry]
Name=Game 471xxxxxxxxxxxx348
Exec=/home/sander/Documents/Aftermath/bin/gamefݝ$ %u
Type=Application
NoDisplay=true
Categories=Discord;Games;
MimeType=x-scheme-handler/discord-471xxxxxxxxxxxx348;
```
The three characters themselves are arbitrary; they changed when my game was launched again.

### The fix
The man page of [readlink](http://man7.org/linux/man-pages/man2/readlink.2.html) told me that readlink never appends a null character to the buffer, so I think `exePath` should be manually null-terminated before using it as `command`. If `size == sizeof(exePath)`, the entire buffer is used and there is no more room for a null character; to avoid a segfault the function just returns. A full buffer means the path might have been truncated, so `exePath` is probably useless anyway.

Contents of *~/.local/share/applications/discord-471xxxxxxxxxxxx348.desktop* after the fix:
```
[Desktop Entry]
Name=Game 471xxxxxxxxxxxx348
Exec=/home/sander/Documents/Aftermath/bin/game %u
Type=Application
NoDisplay=true
Categories=Discord;Games;
MimeType=x-scheme-handler/discord-471xxxxxxxxxxxx348;
```
