### PR TITLE
Fix mismatched signs in comparison after b44defe

### DIFF
--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -34,7 +34,7 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
     char exePath[1024];
     if (!command || !command[0]) {
         ssize_t size = readlink("/proc/self/exe", exePath, sizeof(exePath));
-        if (size <= 0 || size >= sizeof(exePath)) {
+        if (size <= 0 || size >= (ssize_t)sizeof(exePath)) {
             return;
         }
         exePath[size] = '\0';


### PR DESCRIPTION
```
../src/discord_register_linux.cpp: In function ‘void Discord_Register(const char*, const char*)’:
../src/discord_register_linux.cpp:37:31: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and ‘long unsigned int’ [-Wsign-compare]
         if (size <= 0 || size >= sizeof(exePath)) {
                          ~~~~~^~~~~~~~~~~~~~~~~~
```