### PR TITLE
Fix #210: WARNINGS_AS_ERRORS doesn't work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,5 @@ before_install:
 script:
     - mkdir build
     - cd build
-    - cmake -DCLANG_FORMAT_SUFFIX=$CLANG_FORMAT_SUFFIX --config Release ..
+    - cmake -DCLANG_FORMAT_SUFFIX=$CLANG_FORMAT_SUFFIX -DWARNINGS_AS_ERRORS=On --config Release ..
     - cmake --build . -- -j2


### PR DESCRIPTION
#210 was created under assumption `build.py` is actually used, but upon
inspecting `.travis.yml` it turns out it is not.