### PR TITLE
Improve handling of disconnects and reconnects

### DIFF
--- a/src/connection_unix.cpp
+++ b/src/connection_unix.cpp
@@ -118,5 +118,8 @@ bool BaseConnection::Read(void* data, size_t length)
         }
         Close();
     }
+    else if (res == 0) {
+        Close();
+    }
     return res == (int)length;
 }

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -355,6 +355,8 @@ extern "C" DISCORD_EXPORT void Discord_Shutdown(void)
     Connection->onConnect = nullptr;
     Connection->onDisconnect = nullptr;
     Handlers = {};
+    CurrentPresence.length = 0;
+    QueuedPresence.length = 0;
     if (IoThread != nullptr) {
         IoThread->Stop();
         delete IoThread;


### PR DESCRIPTION
From recv(): The return value will be 0 when the peer has performed an orderly shutdown

This way it should notice that the connection was closed when trying to read, forcing it to try and reconnect automatically instead of on write.

Another issue I've found lies in https://github.com/discordapp/discord-rpc/blob/e32d001809c4aad56cef2a5321b54442d830174f/src/discord_rpc.cpp#L338-L341

Here it changes the handlers to `{}` meaning the `disconnected` handler will not be called, is this intentional?