### PR TITLE
Update D binding link: DerelictDiscordRPC has been supersed by Discord RPC D

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Below is a table of unofficial, community-developed wrappers for and implementat
 | Name                                                                      | Language                          |
 | ------------------------------------------------------------------------- | --------------------------------- |
 | [Discord RPC C#](https://github.com/Lachee/discord-rpc-csharp)            | C#                                |
-| [DerelictDiscordRPC](https://github.com/voidblaster/DerelictDiscordRPC)   | [D](https://dlang.org/)           |
+| [Discord RPC D](https://github.com/voidblaster/discord-rpc-d)             | [D](https://dlang.org/)           |
 | [discord-rpc.jar](https://github.com/Vatuu/discord-rpc 'Discord-RPC.jar') | Java                              |
 | [java-discord-rpc](https://github.com/MinnDevelopment/java-discord-rpc)   | Java                              |
 | [Discord-IPC](https://github.com/jagrosh/DiscordIPC)                      | Java                              |


### PR DESCRIPTION
*DerelictDiscordRPC* (https://github.com/discordapp/discord-rpc/pull/169) has been *abandoned* and superseded by **[Discord RPC D](https://github.com/voidblaster/discord-rpc-d)**.

The new binding is a static one and doesn't use Derelict anymore. This makes it more versatile - since it's possible to use it alongside other bindings depending on older Derelict versions. Furthermore, this should solve a few other possible problems that could occur with the old one.

Thanks to @WebFreak001 and @Vild for helping me testing this.
Also thanks to you, guys, for your great chat client :slightly_smiling_face: 