### PR TITLE
Add target_include_directories along with include_directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
 option(ENABLE_IO_THREAD "Start up a separate I/O thread, otherwise I'd need to call an update function" ON)
 option(USE_STATIC_CRT "Use /MT[d] for dynamic library" OFF)
 option(WARNINGS_AS_ERRORS "When enabled, compiles with `-Werror` (on *nix platforms)." OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,6 @@ if(UNIX)
     endif(APPLE)
 
     add_library(discord-rpc ${BASE_RPC_SRC})
-    target_include_directories(discord-rpc INTERFACE ${PROJECT_SOURCE_DIR}/include)
     target_link_libraries(discord-rpc PUBLIC pthread)
 
     if (APPLE)
@@ -110,6 +109,7 @@ if(UNIX)
     endif (APPLE)
 endif(UNIX)
 
+target_include_directories(discord-rpc INTERFACE ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(discord-rpc PRIVATE ${RAPIDJSON}/include)
 
 if (NOT ${ENABLE_IO_THREAD})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 option(ENABLE_IO_THREAD "Start up a separate I/O thread, otherwise I'd need to call an update function" ON)
 option(USE_STATIC_CRT "Use /MT[d] for dynamic library" OFF)
 option(WARNINGS_AS_ERRORS "When enabled, compiles with `-Werror` (on *nix platforms)." OFF)
@@ -71,6 +69,7 @@ if(UNIX)
     endif(APPLE)
 
     add_library(discord-rpc ${BASE_RPC_SRC})
+    target_include_directories(discord-rpc INTERFACE ${PROJECT_SOURCE_DIR}/include)
     target_link_libraries(discord-rpc PUBLIC pthread)
 
     if (APPLE)


### PR DESCRIPTION
So, I'm trying to make a game even cooler than it already is with the discord-rpc, but I noticed that when I linked discord to my cmake target in the following way, it doesn't know where the header files are.

```
# Root CMakeLists.txt

# CMake Setup
cmake_minimum_required(VERSION 3.13.0)
project(CoolGame)

add_executable(CoolGame)                # Telling CMake where to put my game
add_subdirectory(extern/discord-rpc)    # Tell CMake where discord-rpc is located
add_subdirectory(src)                   # Tell CMake where my game source is located

# Link discord
target_link_libraries(CoolGame discord-rpc)  # Doesn't work how one would expect
```
All the other libraries I have that make the game cooler use the `target_include_directories` and here's the main difference.

`include_directories` is only going to add the given directory to the `INCLUDE_DIRECTORIES` list of the current `CMakeLists.txt` file. Which would be great if discord and my game were defined in the same file, but they aren't. My CMakeLists.txt is separate in the `src` directory.

`target_include_directories` tells CMake to relate a given list of directories to a given target, in this case, the library target you create when you run `add_library(discord-rpc)`. Good thing about the `add_library` is that the target name parameter is globally accessible, so I can properly link the library to my game when I run `target_link_libraries(CoolGame discord-rpc)` and access the headers, all with one line of code.

Hope I answered all the questions ahead of time. Let me know if there's something I could do to help get this merged.