### PR TITLE
Fix evil allocations, marshaling overhead

### DIFF
--- a/examples/button-clicker/Assets/DiscordRpc.cs
+++ b/examples/button-clicker/Assets/DiscordRpc.cs
@@ -132,6 +132,8 @@ public class DiscordRpc
     {
         private RichPresenceStruct _presence;
         private readonly List<IntPtr> _buffers = new List<IntPtr>(10);
+        private char[] _chrBuffer = new char[128];
+        private byte[] _byteBuffer = new byte[385]; // utf8 char max 4 bytes in worst case
 
         public string state; /* max 128 bytes */
         public string details; /* max 128 bytes */
@@ -189,14 +191,12 @@ public class DiscordRpc
         private IntPtr StrToPtr(string input)
         {
             if (string.IsNullOrEmpty(input)) return IntPtr.Zero;
-            var convbytecnt = Encoding.UTF8.GetByteCount(input);
-            var buffer = Marshal.AllocHGlobal(convbytecnt + 1);
-            for (int i = 0; i < convbytecnt + 1; i++)
-            {
-                Marshal.WriteByte(buffer, i, 0);
-            }
+            var len = input.Length > 128 ? 128 : input.Length;
+            input.CopyTo(0, _chrBuffer, 0, len);
+            var convbytecnt = Encoding.UTF8.GetBytes(_chrBuffer, 0, len, _byteBuffer, 0);
+            IntPtr buffer = Marshal.AllocHGlobal(convbytecnt + 1);
             _buffers.Add(buffer);
-            Marshal.Copy(Encoding.UTF8.GetBytes(input), 0, buffer, convbytecnt);
+            Marshal.Copy(_byteBuffer, 0, buffer, convbytecnt);
             return buffer;
         }
 

--- a/examples/button-clicker/Assets/DiscordRpc.cs
+++ b/examples/button-clicker/Assets/DiscordRpc.cs
@@ -195,6 +195,7 @@ public class DiscordRpc
             input.CopyTo(0, _chrBuffer, 0, len);
             var convbytecnt = Encoding.UTF8.GetBytes(_chrBuffer, 0, len, _byteBuffer, 0);
             IntPtr buffer = Marshal.AllocHGlobal(convbytecnt + 1);
+            Marshal.WriteByte(buffer, convbytecnt, 0);
             _buffers.Add(buffer);
             Marshal.Copy(_byteBuffer, 0, buffer, convbytecnt);
             return buffer;


### PR DESCRIPTION
StrToPtr() had at least 4 extra allocations of byte[] and char[] arrays that will make Unity's GC and frametime stability sad, taking into account you can updated 5 times per 20 seconds, which is few frames apart.
Also, there was 0 reason to have that marshaling invoke overhead where it zeroes byte by byte in a loop. There is no point, we already overwrite whole memory via .Copy() and we only allocate as much as needed for the string bytes, no extra. No security concerns here.

The only question that eludes me is the limitation of 128 bytes. It was not enforced on managed side in old code, and I could not find anything in native library. So I assume it is enforced on RPC server side then? Either way since limit is 128 bytes aka 128 ASCII characters at min, it makes sense to limit allocated data to 128 chars max to avoid sending perhaps megabytes of mistakenly generated by user string (I assume it will throw in pipe/socket).
