### PR TITLE
Add some library versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.2.0)
 project (DiscordRPC)
+set(DRPC_VERSION 3.4.0)
 
 include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ if(UNIX)
     endif(APPLE)
 
     add_library(discord-rpc ${BASE_RPC_SRC})
+    set_target_properties(discord-rpc PROPERTIES SOVERSION ${DRPC_VERSION})
     target_link_libraries(discord-rpc PUBLIC pthread)
 
     if (APPLE)


### PR DESCRIPTION
discord-rpc silently changed ABI between v3.0.0 and v3.4.0.
This requires DT_SONAME changes. Implement something that fulfills the tagging requirements for distributions.