### PR TITLE
Remove duplicate `IndentCaseLabels` key in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,7 +34,6 @@ DerivePointerAlignment: false
 DisableFormat: false
 FixNamespaceComments: true
 ForEachMacros: []
-IndentCaseLabels: false
 IncludeCategories:
   - Regex: '^("|<)stdafx\.h(pp)?("|>)'
     Priority: -1


### PR DESCRIPTION
We've started getting some failures building a [project](https://github.com/open-goal/jak-project) that uses discord-rpc due to this:
> error G6B07872C: duplicated mapping key 'IndentCaseLabels'

(it appears on both line 37 and line 48)