### PR TITLE
Remove duplicate declaration "IndentCaseLabels"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,6 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IncludeIsMainRegex: '(_test|_win|_linux|_mac|_ios|_osx|_null)?$'
-IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false


### PR DESCRIPTION
`IndentCaseLabels` was already present in line 37 which clang-format started to complain about. I know this project is deprecated and likely EOL, yet I hope you can still merge this.