### PR TITLE
Update deprecation notice for Discord SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Deprecation Notice
 
-This library has been deprecated in favor of Discord's GameSDK. [Learn more here](https://discordapp.com/developers/docs/game-sdk/sdk-starter-guide)
+This library has been deprecated in favor of Discord's <s>GameSDK</s> Social SDK. [Learn more here](https://docs.discord.com/developers/discord-social-sdk/overview#discord-social-sdk)
 
 ---
 


### PR DESCRIPTION
Game SDK is now also deprecated/archived in favour of Discord's Social SDK, according to the docs: https://docs.discord.com/developers/rich-presence/overview#game-sdk